### PR TITLE
Add psmisc to yum install

### DIFF
--- a/doc/install/install_via_centos7.md
+++ b/doc/install/install_via_centos7.md
@@ -16,7 +16,7 @@ Please remember to replace 'ip.add.re.ss' with your server's actual IP address (
 yum update
 
 # Install required packages
-yum install -y yum-utils
+yum install -y yum-utils psmisc
 
 # Hostname setup
 hostnamectl set-hostname aio.kazoo.com


### PR DESCRIPTION
killall is used in /sbin/kazoo-* scripts, but isn't installed by default on CentOS 7