### PR TITLE
Add socat to Required Packages

### DIFF
--- a/doc/install/install_via_centos7.md
+++ b/doc/install/install_via_centos7.md
@@ -41,7 +41,7 @@ LATEST_RELEASE=${RELEASE_BASE}/${RELEASE_VER}/${META_PKG}
 yum update
 
 # Install required packages
-yum install -y yum-utils psmisc
+yum install -y yum-utils psmisc socat
 
 # Hostname setup
 hostnamectl set-hostname ${_HOSTNAME}


### PR DESCRIPTION
socat is not included in a CentOS 7 minimal installation and is required by kazoo-haproxy