### PR TITLE
Update installation order on install_via_centos7.md

### DIFF
--- a/doc/install/install_via_centos7.md
+++ b/doc/install/install_via_centos7.md
@@ -49,12 +49,6 @@ yum install -y epel-release
 # Install required packages
 yum install -y yum-utils psmisc
 
-# Download and install updated FreeSWITCH repository
-echo "signalwire" > /etc/yum/vars/signalwireusername
-echo ${TOKEN} > /etc/yum/vars/signalwiretoken
-wget https://$(< /etc/yum/vars/signalwireusername):$(< /etc/yum/vars/signalwiretoken)@freeswitch.signalwire.com/repo/yum/centos-release/freeswitch-release-repo-0-1.noarch.rpm
-rpm -i --replacefiles freeswitch-release-repo-0-1.noarch.rpm
-
 # Hostname setup
 hostnamectl set-hostname ${_HOSTNAME}
 
@@ -87,6 +81,12 @@ Example:  yum install -y https://packages.2600hz.com/centos/7/stable/2600hz-rele
 
 # Clear yum cache
 yum clean all
+
+# Download and install updated FreeSWITCH repository
+echo "signalwire" > /etc/yum/vars/signalwireusername
+echo ${TOKEN} > /etc/yum/vars/signalwiretoken
+wget https://$(< /etc/yum/vars/signalwireusername):$(< /etc/yum/vars/signalwiretoken)@freeswitch.signalwire.com/repo/yum/centos-release/freeswitch-release-repo-0-1.noarch.rpm
+rpm -i --replacefiles freeswitch-release-repo-0-1.noarch.rpm
 
 # Setup NTPd
 yum install -y ntp


### PR DESCRIPTION
The original order of commands would result on a package conflict error. 

Installing Freeswitch rpm before the Kazoo package would cause the error below, as reported on [this forum post](https://forums.2600hz.com/forums/topic/14058-installing-kazoo-transaction-check-error):
![image](https://github.com/user-attachments/assets/44a1482f-afc9-4ae6-93ce-23dd143b03b8)


So, after following the suggestion of this [forum answer](https://forums.2600hz.com/forums/topic/14058-installing-kazoo-transaction-check-error/?do=findComment&comment=75281), I decided to propose these changes.